### PR TITLE
[Hotfix] Corrige tratamento de erros no SDK PagHiper

### DIFF
--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -76,7 +76,8 @@ class Request
             return $data;
         } catch (RequestException $e) {
             if ($e->hasResponse()) {
-                $data = \GuzzleHttp\json_decode($e->getResponseBodySummary($e->getResponse()), true);
+                $body = (string) $e->getResponse()->getBody();
+                $data = \GuzzleHttp\json_decode($body, true);
 
                 if ($data = (reset($data)['response_message'] ?? false)) {
                     // Tentar buscar mensagem de erro


### PR DESCRIPTION
## Hotfix

Corrige bug no tratamento de exceções HTTP do SDK que causava erro fatal do PHP.

### Problema

Quando a API da PagHiper retornava erro HTTP (4xx/5xx), o SDK chamava um método inexistente:

```php
$e->getResponseBodySummary($e->getResponse())
```

**Erro gerado:**
```
Error: Call to undefined method GuzzleHttp\Exception\ClientException::getResponseBodySummary()
```

### Solução

Substituído por leitura direta do body da resposta:

```php
$body = (string) $e->getResponse()->getBody();
$data = \GuzzleHttp\json_decode($body, true);
```

### Impacto

| Componente | Antes | Depois |
|------------|-------|--------|
| Cliente final | Mensagem genérica | Mensagem genérica (sem mudança) |
| Lojista (admin) | "Call to undefined method..." | Mensagem real (ex: "CPF inválido") |
| Logs | Erro técnico | Mensagem real do gateway |

### Arquivo alterado

- `src/Request/Request.php`

### Validação

✅ Testado com chamadas reais à API PagHiper usando credenciais inválidas  
✅ SDK agora lança `ErrorException` corretamente
